### PR TITLE
ADD - webpacker 추가

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -1,0 +1,39 @@
+default: &default
+  source_path: app/javascript
+  source_entry_path: packs
+  public_root_path: public
+  public_output_path: packs
+  cache_path: tmp/cache/webpacker
+  check_yarn_integrity: false
+  webpack_compile_output: true
+
+  resolved_paths: []
+  cache_manifest: false
+
+  extensions:
+    - .mjs
+    - .js
+    - .sass
+    - .scss
+    - .css
+    - .module.sass
+    - .module.scss
+    - .module.css
+    - .png
+    - .svg
+    - .gif
+    - .jpeg
+    - .jpg
+
+development:
+  <<: *default
+  compile: true
+
+test:
+  <<: *default
+  compile: true
+
+production:
+  <<: *default
+  compile: false
+  cache_manifest: true


### PR DESCRIPTION
## Context
webpacker 파일이 없어서 발생하는 문제
```
crema@cremaui-MacBookPro rails_tutorial % bin/rails server
/Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/net/protocol.rb:66: warning: already initialized constant Net::ProtocRetryError
/Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/net-protocol-0.2.2/lib/net/protocol.rb:68: warning: previous definition of ProtocRetryError was here
/Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/net/protocol.rb:206: warning: already initialized constant Net::BufferedIO::BUFSIZE
/Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/net-protocol-0.2.2/lib/net/protocol.rb:214: warning: previous definition of BUFSIZE was here
/Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/net/protocol.rb:503: warning: already initialized constant Net::NetPrivate::Socket
/Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/net-protocol-0.2.2/lib/net/protocol.rb:541: warning: previous definition of Socket was here
=> Booting Puma
=> Rails 6.1.7.10 application starting in development 
=> Run `bin/rails server --help` for more startup options
Exiting
Traceback (most recent call last):
        64: from bin/rails:2:in `<main>'
        63: from bin/rails:2:in `load'
        62: from /Users/crema/Desktop/folder/rails_tutorial/bin/spring:7:in `<top (required)>'
        61: from /Users/crema/Desktop/folder/rails_tutorial/bin/spring:7:in `tap'
        60: from /Users/crema/Desktop/folder/rails_tutorial/bin/spring:10:in `block in <top (required)>'
        59: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
        58: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
        57: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/spring-4.3.0/lib/spring/binstub.rb:11:in `<top (required)>'
        56: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/spring-4.3.0/lib/spring/binstub.rb:11:in `load'
        55: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/spring-4.3.0/bin/spring:49:in `<top (required)>'
        54: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/spring-4.3.0/lib/spring/client.rb:30:in `run'
        53: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/spring-4.3.0/lib/spring/client/command.rb:7:in `call'
        52: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/spring-4.3.0/lib/spring/client/rails.rb:28:in `call'
        51: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/spring-4.3.0/lib/spring/client/rails.rb:28:in `load'
        50: from /Users/crema/Desktop/folder/rails_tutorial/bin/rails:5:in `<top (required)>'
        49: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        48: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        47: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/commands.rb:18:in `<main>'
        46: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/command.rb:48:in `invoke'
        45: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/command/base.rb:69:in `perform'
        44: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/thor-1.4.0/lib/thor.rb:538:in `dispatch'
        43: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/thor-1.4.0/lib/thor/invocation.rb:127:in `invoke_command'
        42: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/thor-1.4.0/lib/thor/command.rb:28:in `run'
        41: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/commands/server/server_command.rb:135:in `perform'
        40: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/commands/server/server_command.rb:135:in `tap'
        39: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/commands/server/server_command.rb:144:in `block in perform'
        38: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/commands/server/server_command.rb:37:in `start'
        37: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/commands/server/server_command.rb:77:in `log_to_stdout'
        36: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.17/lib/rack/server.rb:422:in `wrapped_app'
        35: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.17/lib/rack/server.rb:249:in `app'
        34: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.17/lib/rack/server.rb:349:in `build_app_and_options_from_config'
        33: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.17/lib/rack/builder.rb:66:in `parse_file'
        32: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.17/lib/rack/builder.rb:105:in `load_file'
        31: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.17/lib/rack/builder.rb:116:in `new_from_string'
        30: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.17/lib/rack/builder.rb:116:in `eval'
        29: from config.ru:3:in `block in <main>'
        28: from config.ru:3:in `require_relative'
        27: from /Users/crema/Desktop/folder/rails_tutorial/config/environment.rb:5:in `<main>'
        26: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/application.rb:391:in `initialize!'
        25: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/initializable.rb:60:in `run_initializers'
        24: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:205:in `tsort_each'
        23: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:226:in `tsort_each'
        22: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:347:in `each_strongly_connected_component'
        21: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:347:in `call'
        20: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:347:in `each'
        19: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:349:in `block in each_strongly_connected_component'
        18: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:431:in `each_strongly_connected_component_from'
        17: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
        16: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:228:in `block in tsort_each'
        15: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/initializable.rb:61:in `block in run_initializers'
        14: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/initializable.rb:32:in `run'
        13: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/initializable.rb:32:in `instance_exec'
        12: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/railtie.rb:41:in `block in <class:Engine>'
        11: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker.rb:35:in `bootstrap'
        10: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/commands.rb:47:in `bootstrap'
         9: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/manifest.rb:18:in `refresh'
         8: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/manifest.rb:83:in `load'
         7: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/configuration.rb:51:in `public_manifest_path'
         6: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/configuration.rb:47:in `public_output_path'
         5: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/configuration.rb:43:in `public_path'
         4: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/configuration.rb:88:in `fetch'
         3: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/configuration.rb:92:in `data'
         2: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/configuration.rb:97:in `load'
         1: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/bootsnap-1.18.6/lib/bootsnap/compile_cache/yaml.rb:301:in `load_file'
/Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/psych.rb:576:in `load_file': unknown keyword: :aliases (ArgumentError)
        65: from bin/rails:2:in `<main>'
        64: from bin/rails:2:in `load'
        63: from /Users/crema/Desktop/folder/rails_tutorial/bin/spring:7:in `<top (required)>'
        62: from /Users/crema/Desktop/folder/rails_tutorial/bin/spring:7:in `tap'
        61: from /Users/crema/Desktop/folder/rails_tutorial/bin/spring:10:in `block in <top (required)>'
        60: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
        59: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
        58: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/spring-4.3.0/lib/spring/binstub.rb:11:in `<top (required)>'
        57: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/spring-4.3.0/lib/spring/binstub.rb:11:in `load'
        56: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/spring-4.3.0/bin/spring:49:in `<top (required)>'
        55: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/spring-4.3.0/lib/spring/client.rb:30:in `run'
        54: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/spring-4.3.0/lib/spring/client/command.rb:7:in `call'
        53: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/spring-4.3.0/lib/spring/client/rails.rb:28:in `call'
        52: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/spring-4.3.0/lib/spring/client/rails.rb:28:in `load'
        51: from /Users/crema/Desktop/folder/rails_tutorial/bin/rails:5:in `<top (required)>'
        50: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        49: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        48: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/commands.rb:18:in `<main>'
        47: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/command.rb:48:in `invoke'
        46: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/command/base.rb:69:in `perform'
        45: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/thor-1.4.0/lib/thor.rb:538:in `dispatch'
        44: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/thor-1.4.0/lib/thor/invocation.rb:127:in `invoke_command'
        43: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/thor-1.4.0/lib/thor/command.rb:28:in `run'
        42: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/commands/server/server_command.rb:135:in `perform'
        41: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/commands/server/server_command.rb:135:in `tap'
        40: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/commands/server/server_command.rb:144:in `block in perform'
        39: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/commands/server/server_command.rb:37:in `start'
        38: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/commands/server/server_command.rb:77:in `log_to_stdout'
        37: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.17/lib/rack/server.rb:422:in `wrapped_app'
        36: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.17/lib/rack/server.rb:249:in `app'
        35: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.17/lib/rack/server.rb:349:in `build_app_and_options_from_config'
        34: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.17/lib/rack/builder.rb:66:in `parse_file'
        33: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.17/lib/rack/builder.rb:105:in `load_file'
        32: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.17/lib/rack/builder.rb:116:in `new_from_string'
        31: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.17/lib/rack/builder.rb:116:in `eval'
        30: from config.ru:3:in `block in <main>'
        29: from config.ru:3:in `require_relative'
        28: from /Users/crema/Desktop/folder/rails_tutorial/config/environment.rb:5:in `<main>'
        27: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/application.rb:391:in `initialize!'
        26: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/initializable.rb:60:in `run_initializers'
        25: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:205:in `tsort_each'
        24: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:226:in `tsort_each'
        23: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:347:in `each_strongly_connected_component'
        22: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:347:in `call'
        21: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:347:in `each'
        20: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:349:in `block in each_strongly_connected_component'
        19: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:431:in `each_strongly_connected_component_from'
        18: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
        17: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:228:in `block in tsort_each'
        16: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/initializable.rb:61:in `block in run_initializers'
        15: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/initializable.rb:32:in `run'
        14: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/initializable.rb:32:in `instance_exec'
        13: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/railtie.rb:41:in `block in <class:Engine>'
        12: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker.rb:35:in `bootstrap'
        11: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/commands.rb:47:in `bootstrap'
        10: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/manifest.rb:18:in `refresh'
         9: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/manifest.rb:83:in `load'
         8: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/configuration.rb:51:in `public_manifest_path'
         7: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/configuration.rb:47:in `public_output_path'
         6: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/configuration.rb:43:in `public_path'
         5: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/configuration.rb:88:in `fetch'
         4: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/configuration.rb:92:in `data'
         3: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/configuration.rb:96:in `load'
         2: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/configuration.rb:99:in `rescue in load'
         1: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/bootsnap-1.18.6/lib/bootsnap/compile_cache/yaml.rb:306:in `load_file'
/Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/bootsnap-1.18.6/lib/bootsnap/compile_cache/yaml.rb:306:in `realpath': No such file or directory @ rb_check_realpath_internal - /Users/crema/Desktop/folder/rails_tutorial/config/webpacker.yml (Errno::ENOENT)
        63: from bin/rails:2:in `<main>'
        62: from bin/rails:2:in `load'
        61: from /Users/crema/Desktop/folder/rails_tutorial/bin/spring:7:in `<top (required)>'
        60: from /Users/crema/Desktop/folder/rails_tutorial/bin/spring:7:in `tap'
        59: from /Users/crema/Desktop/folder/rails_tutorial/bin/spring:10:in `block in <top (required)>'
        58: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
        57: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
        56: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/spring-4.3.0/lib/spring/binstub.rb:11:in `<top (required)>'
        55: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/spring-4.3.0/lib/spring/binstub.rb:11:in `load'
        54: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/spring-4.3.0/bin/spring:49:in `<top (required)>'
        53: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/spring-4.3.0/lib/spring/client.rb:30:in `run'
        52: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/spring-4.3.0/lib/spring/client/command.rb:7:in `call'
        51: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/spring-4.3.0/lib/spring/client/rails.rb:28:in `call'
        50: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/spring-4.3.0/lib/spring/client/rails.rb:28:in `load'
        49: from /Users/crema/Desktop/folder/rails_tutorial/bin/rails:5:in `<top (required)>'
        48: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        47: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        46: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/commands.rb:18:in `<main>'
        45: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/command.rb:48:in `invoke'
        44: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/command/base.rb:69:in `perform'
        43: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/thor-1.4.0/lib/thor.rb:538:in `dispatch'
        42: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/thor-1.4.0/lib/thor/invocation.rb:127:in `invoke_command'
        41: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/thor-1.4.0/lib/thor/command.rb:28:in `run'
        40: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/commands/server/server_command.rb:135:in `perform'
        39: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/commands/server/server_command.rb:135:in `tap'
        38: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/commands/server/server_command.rb:144:in `block in perform'
        37: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/commands/server/server_command.rb:37:in `start'
        36: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/commands/server/server_command.rb:77:in `log_to_stdout'
        35: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.17/lib/rack/server.rb:422:in `wrapped_app'
        34: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.17/lib/rack/server.rb:249:in `app'
        33: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.17/lib/rack/server.rb:349:in `build_app_and_options_from_config'
        32: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.17/lib/rack/builder.rb:66:in `parse_file'
        31: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.17/lib/rack/builder.rb:105:in `load_file'
        30: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.17/lib/rack/builder.rb:116:in `new_from_string'
        29: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rack-2.2.17/lib/rack/builder.rb:116:in `eval'
        28: from config.ru:3:in `block in <main>'
        27: from config.ru:3:in `require_relative'
        26: from /Users/crema/Desktop/folder/rails_tutorial/config/environment.rb:5:in `<main>'
        25: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/application.rb:391:in `initialize!'
        24: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/initializable.rb:60:in `run_initializers'
        23: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:205:in `tsort_each'
        22: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:226:in `tsort_each'
        21: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:347:in `each_strongly_connected_component'
        20: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:347:in `call'
        19: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:347:in `each'
        18: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:349:in `block in each_strongly_connected_component'
        17: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:431:in `each_strongly_connected_component_from'
        16: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
        15: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/2.7.0/tsort.rb:228:in `block in tsort_each'
        14: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/initializable.rb:61:in `block in run_initializers'
        13: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/initializable.rb:32:in `run'
        12: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/railties-6.1.7.10/lib/rails/initializable.rb:32:in `instance_exec'
        11: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/railtie.rb:41:in `block in <class:Engine>'
        10: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker.rb:35:in `bootstrap'
         9: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/commands.rb:47:in `bootstrap'
         8: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/manifest.rb:18:in `refresh'
         7: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/manifest.rb:83:in `load'
         6: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/configuration.rb:51:in `public_manifest_path'
         5: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/configuration.rb:47:in `public_output_path'
         4: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/configuration.rb:43:in `public_path'
         3: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/configuration.rb:88:in `fetch'
         2: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/configuration.rb:92:in `data'
         1: from /Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/configuration.rb:95:in `load'
/Users/crema/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/webpacker-5.4.4/lib/webpacker/configuration.rb:103:in `rescue in load': Webpacker configuration file not found /Users/crema/Desktop/folder/rails_tutorial/config/webpacker.yml. Please run rails webpacker:install Error: No such file or directory @ rb_check_realpath_internal - /Users/crema/Desktop/folder/rails_tutorial/config/webpacker.yml (RuntimeError)
```

## Change
`/config/webpacker.yml` 파일 추가

## Task
- asana 링크가 있다면 달아야 합니다.